### PR TITLE
Add requests dependency.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -12,6 +12,8 @@ setup(
     license="MIT",
     author="Dcard",
     packages=find_packages(),
-    install_requires=[],
+    install_requires=[
+        "requests"
+    ],
     long_description=long_description
 )


### PR DESCRIPTION
requests are not python built-in packages, need to be set as install requires.
